### PR TITLE
fix bug, stateful sest is not last string

### DIFF
--- a/build_image/run.sh
+++ b/build_image/run.sh
@@ -6,7 +6,7 @@ sed -i "s/NAMESPACE/$NAMESPACE/" /etc/clickhouse-server/config.xml
 sed -i "s/KUBERNETES_DOMAIN/$KUBERNETES_DOMAIN/" /etc/clickhouse-server/config.xml
 sed -i "s/CLUSTER_NAME/$CLUSTER_NAME/" /etc/clickhouse-server/config.xml
 
-NODE_ID=$(echo $(hostname) | awk '{print substr($0,length,1)}')
+NODE_ID=$(echo $(hostname) | awk '{print substr($0,length-2,1)}')
 
 cp /opt/macro-$NODE_ID.xml /etc/clickhouse-server/macro.xml
 


### PR DESCRIPTION
in my cluster, it hostname is  clickhouse-0-0,  clickhouse-1-0
so we want to substr the increment number 0, 1 ,2 , we need correct extract the number string.

report at issue https://github.com/count0ru/k8s-clickhouse-v2/issues/2